### PR TITLE
ログインセッション時間の調整

### DIFF
--- a/my_record/settings.py
+++ b/my_record/settings.py
@@ -151,3 +151,6 @@ MARKDOWNX_MARKDOWN_EXTENSIONS = [
 ]
 
 FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
+
+# ログインセッションタイムアウト時間(1日)
+SESSION_COOKIE_AGE = 86400


### PR DESCRIPTION
ログインしてから一定時間経過したら強制的にログアウトするようにする。
セキュリティ上ずっとログインしていると、乗っ取りとかがあるとユーザーの情報がバレバレになってしまうため。

デフォルト：2週間
変更後：1日
※タイマーの計測で1時間とか操作しない時があるため、1日でセッションタイムアウトさせる。